### PR TITLE
Navbar 생성, 폰트 적용

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,9 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,200..900;1,7..72,200..900&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.2.1",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.23.1"
       },
@@ -3555,6 +3556,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-redux": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.2.1",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.23.1"
   },

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,16 @@
+// import React from 'react'
+import { Outlet } from "react-router-dom";
+import Navbar from "./Navbar/Navbar";
+
+// type Props = {}
+
+export default function Layout() {
+  return (
+    <div>
+        <Navbar />
+        <div>
+            <Outlet />
+        </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -1,0 +1,38 @@
+// import React from 'react'
+import { NavLink } from "react-router-dom";
+import { IoMdSearch } from "react-icons/io";
+
+export default function Navbar() {
+  return (
+    <nav className="bg-black fixed w-full h-fit py-[0.75em] px-[1.5rem] top-0 flex justify-between">
+      <div className="flex gap-[2rem] items-center">
+        <NavLink to="/">
+          <p className="text-white text-[20px]">
+            <span className="text-[35px]">T</span>yper
+          </p>
+        </NavLink>
+
+        <div className="relative">
+          <IoMdSearch className="absolute top-[25%] left-[10px]"/>
+          <input className="h-[30px] rounded-full pl-[30px] pr-[10px] py-[5px] bg-[#E5E5E5]" />
+        </div>
+      </div>
+
+      <div className="flex gap-[1rem] items-center">
+        <div>
+          <NavLink to="/editor">
+            <p className="text-[#E5E5E5] text-xl hover:text-white">Write</p>
+          </NavLink>
+        </div>
+
+        <div>
+          <NavLink to="/my" className="bg-white">
+            <img 
+            className="w-[40px] rounded-full"
+            src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU"/>
+          </NavLink>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@font-face {
+    font-family: "Literata", serif;
+    font-optical-sizing: auto;
+    font-weight: 400;
+    font-style: normal;  
+    src: url("https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,200..900;1,7..72,200..900&display=swap");
+    unicode-range: U+0030-0039, U+0041-005A, U+0061-007A;
+}
+
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+    unicode-range: U+1100-11FF, U+3130-318F, U+A960-A97F, U+AC00-D7A3, U+D7B0-D7FF;
+}
+
+* { 
+    font-family: 'Pretendard-Regular', "Literata";
+}

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -4,6 +4,8 @@ import PostDetail from "./routes/postDetail/PostDetailPage";
 import MyPage from "./routes/my/MyPage";
 import EditorPage from "./routes/editor/EditorPage";
 
+import Layout from "./components/Layout";
+
 const routers = [
     {
         path: "/",
@@ -22,8 +24,15 @@ const routers = [
     },
     {
         path: "/post",
-        element: <PostDetail />,
+        element: <Layout />,
         // index: true
+        children: [
+            {
+                path: "",
+                element: <PostDetail />,
+                index: true
+            }
+        ]
     }
 ];
 

--- a/frontend/src/routes/main/MainPage.tsx
+++ b/frontend/src/routes/main/MainPage.tsx
@@ -1,20 +1,16 @@
 // import React from 'react'
-import { useEffect } from "react";
-import postDetailAPI from "../../api/postDetailAPI";
+// import { useEffect } from "react";
+// import postDetailAPI from "../../api/postDetailAPI";
 
 // type Props = {}
 
 export default function MainPage() {
-  const service = new postDetailAPI(import.meta.env.VITE_BASE_URI);
-  useEffect(()=>{
-    service.getPostInfo("id어쩌구저쩌구")
-    .then(res=>console.log(res))
-    .catch(e=>console.log(e));
-  }, []);
-  
-  return (
-    <div
-    className="bg-red-500"
-    >MainPage</div>
-  )
+  // const service = new postDetailAPI(import.meta.env.VITE_BASE_URI);
+  // useEffect(()=>{
+  //   service.getPostInfo("id어쩌구저쩌구")
+  //   .then(res=>console.log(res))
+  //   .catch(e=>console.log(e));
+  // }, []);
+
+  return <div>MainPage</div>;
 }


### PR DESCRIPTION
### PR 타입
- [✔️] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [✔️] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
nahyeon -> main

### 변경 사항
- search icon을 위한 react-icons 패키지 설치
- index.css, index.html에 폰트 적용 코드 추가
- navbar 컴포넌트 생성
- navbar 적용 layout 컴포넌트 생성
```
{
        path: "/post",
        element: <Layout />,
        // index: true
        children: [
            {
                path: "",
                element: <PostDetail />,
                index: true
            }
        ]
    }
```
형태로 사용할 수 있습니다.

### 테스트 결과
> http://localhost:5173/post 화면
![image](https://github.com/Typerproject/Frontend/assets/117283341/b6bc43ea-cdea-4a12-ba4e-c5a4c6b9872e)
- 로고 클릭 시 -> mainPage
- write 클릭 시 -> editorPage
- user 이미지 클릭 시 -> myPage
이동하는 것을 확인했습니다.
