### PR TITLE
feat: 마이페이지 헤더, 프로필, 팔로우 UI 기본 구성

### DIFF
--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -7,33 +7,40 @@ import EditorPage from "./routes/editor/EditorPage";
 import Layout from "./components/Layout";
 
 const routers = [
-    {
-        path: "/",
-        element: <MainPage />,
-        // index: true
-    }, 
-    {
-        path: "/my",
+  {
+    path: "/",
+    element: <MainPage />,
+    // index: true
+  },
+  {
+    path: "/my",
+    element: <Layout />,
+    // index: true
+    children: [
+      {
+        path: "",
         element: <MyPage />,
-        // index: true
-    },
-    {
-        path: "/editor",
-        element: <EditorPage />,
-        // index: true
-    },
-    {
-        path: "/post",
-        element: <Layout />,
-        // index: true
-        children: [
-            {
-                path: "",
-                element: <PostDetail />,
-                index: true
-            }
-        ]
-    }
+        index: true,
+      },
+    ],
+  },
+  {
+    path: "/editor",
+    element: <EditorPage />,
+    // index: true
+  },
+  {
+    path: "/post",
+    element: <Layout />,
+    // index: true
+    children: [
+      {
+        path: "",
+        element: <PostDetail />,
+        index: true,
+      },
+    ],
+  },
 ];
 
 const router = createBrowserRouter(routers);

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -11,20 +11,25 @@ export default function MyPage() {
   const following = 53;
 
   return (
-    <div className="mt-[7rem] ">
+    <div className="mt-[7rem]">
       <div className="grid grid-cols-3">
         <div className="col-span-2 flex justify-center  text-5xl">
           <p>{userId}'s Typer</p>
         </div>
-        <div className="col-span-1 flex justify-center items-center">
-          <div className="flex flex-col items-center gap-5">
+        <div className="col-span-1">
+          <div>
             <img className="size-24 rounded-full" src={profileImg} />
-            <p className="text-3xl">{userId}</p>
-            <div className="flex gap-10 text-[#b1b2b3]">
+            <p className="text-3xl mt-[0.5rem] ">{userId}</p>
+            <div className="flex gap-10 text-[#b1b2b3] mt-[0.3rem]">
               <span>{follower} followers</span>
               <span>{following} following</span>
             </div>
-            <p className="flex gap-10 text-[#9d9d9e]">{profileIntro}</p>
+            <p className="flex gap-10 text-[#9d9d9e] mt-[0.5rem]">
+              {profileIntro}
+            </p>
+            <button className="text-xs mt-[0.5rem] border-[1px] bg-black text-white rounded-full border-black text-sm px-[0.7rem] py-[0.3rem] hover:bg-white hover:text-black duration-300">
+              팔로우
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -1,7 +1,7 @@
 // import React from 'react'
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Follow from "./component/Follow";
+import FollowList from "./component/FollowList";
 
 // type Props = {}
 
@@ -98,7 +98,7 @@ export default function MyPage() {
             {follow != false && (
               //클릭 시 해당 사람의 마이페이지로
               <div className="cursor-pointer" onClick={() => navigate(`/post`)}>
-                <Follow />
+                <FollowList />
               </div>
             )}
           </div>

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -3,7 +3,5 @@
 // type Props = {}
 
 export default function MyPage() {
-  return (
-    <div>MyPage</div>
-  )
+  return <div>MyPage</div>;
 }

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -3,5 +3,31 @@
 // type Props = {}
 
 export default function MyPage() {
-  return <div>MyPage</div>;
+  const userId = "CatisCute";
+  const profileImg =
+    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU";
+  const profileIntro = "Cats are cute, but dogs are cuter🐾";
+  const follower = 1231;
+  const following = 53;
+
+  return (
+    <div className="mt-[7rem] ">
+      <div className="grid grid-cols-3">
+        <div className="col-span-2 flex justify-center  text-5xl">
+          <p>{userId}'s Typer</p>
+        </div>
+        <div className="col-span-1 flex justify-center items-center">
+          <div className="flex flex-col items-center gap-5">
+            <img className="size-24 rounded-full" src={profileImg} />
+            <p className="text-3xl">{userId}</p>
+            <div className="flex gap-10 text-[#b1b2b3]">
+              <span>{follower} followers</span>
+              <span>{following} following</span>
+            </div>
+            <p className="flex gap-10 text-[#9d9d9e]">{profileIntro}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -1,35 +1,106 @@
 // import React from 'react'
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Follow from "./component/Follow";
 
 // type Props = {}
 
+type State = "follower" | "following" | false;
+
 export default function MyPage() {
-  const userId = "CatisCute";
-  const profileImg =
-    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU";
-  const profileIntro = "Cats are cute, but dogs are cuter🐾";
-  const follower = 1231;
-  const following = 53;
+  const navigate = useNavigate();
+  const [userName, setUserName] = useState("CatisCute");
+  const [profileImg, setProfileImg] = useState(
+    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU"
+  );
+  const [profileIntro, setProfileIntro] = useState(
+    "Cats are cute, but dogs are cuter🐾"
+  );
+  const [followerCount, setFollowerCount] = useState(1231);
+  const [followingCount, setFollowingCount] = useState(53);
+  const [follow, setFollow] = useState<State>(false);
+
+  const handleFollowerBtn = () => {
+    if (follow != "follower") {
+      setFollow("follower");
+    } else {
+      setFollow(false);
+    }
+  };
+
+  const handleFollowingBtn = () => {
+    if (follow != "following") {
+      setFollow("following");
+    } else {
+      setFollow(false);
+    }
+  };
 
   return (
     <div className="mt-[7rem]">
+      {/*글 목록*/}
       <div className="grid grid-cols-3">
         <div className="col-span-2 flex justify-center  text-5xl">
-          <p>{userId}'s Typer</p>
+          <p>{userName}'s Typer</p>
         </div>
+
+        {/*프로필*/}
         <div className="col-span-1">
           <div>
             <img className="size-24 rounded-full" src={profileImg} />
-            <p className="text-3xl mt-[0.5rem] ">{userId}</p>
-            <div className="flex gap-10 text-[#b1b2b3] mt-[0.3rem]">
-              <span>{follower} followers</span>
-              <span>{following} following</span>
+            <p className="text-3xl mt-[0.7rem] ">{userName}</p>
+
+            <div className={`flex gap-5  mt-[0.5rem] text-[#b1b2b3]`}>
+              <span
+                onClick={handleFollowerBtn}
+                className={`hover:text-[#141414] cursor-pointer  ${
+                  follow === "follower" ? "text-[#141414]" : "text-[#b1b2b3]"
+                }`}
+              >
+                {followerCount} followers
+              </span>
+              <span
+                onClick={handleFollowingBtn}
+                className={`hover:text-[#141414] cursor-pointer ${
+                  follow === "following" ? "text-[#141414]" : "text-[#b1b2b3]"
+                }`}
+              >
+                {followingCount} following
+              </span>
             </div>
-            <p className="flex gap-10 text-[#9d9d9e] mt-[0.5rem]">
+            <p className="flex gap-10 text-[#88898a] mt-[0.7rem]">
               {profileIntro}
             </p>
-            <button className="text-xs mt-[0.5rem] border-[1px] bg-black text-white rounded-full border-black text-sm px-[0.7rem] py-[0.3rem] hover:bg-white hover:text-black duration-300">
+            <button className="text-xs mt-[0.7rem] border-[1px] bg-black text-white rounded-full border-black text-sm px-[0.7rem] py-[0.3rem] hover:bg-white hover:text-black duration-300">
               팔로우
             </button>
+          </div>
+
+          {/*팔로잉팔로우*/}
+          <div>
+            {follow === "follower" && (
+              <div>
+                <div className="mt-[3rem]">
+                  <p className="text-lg">Follower</p>
+                </div>
+              </div>
+            )}
+            {follow === "following" && (
+              <div>
+                <div className="mt-[3rem]">
+                  <p className="text-lg">Following</p>
+                </div>
+              </div>
+            )}
+
+            {/*보여줄 리스트가 팔로잉인지 팔로워인지 구분해서 api 호출
+            가져온 정보 배열을 map 돌면서 props로 넘겨주기*/}
+            {follow != false && (
+              //클릭 시 해당 사람의 마이페이지로
+              <div className="cursor-pointer" onClick={() => navigate(`/post`)}>
+                <Follow />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/routes/my/component/Follow.tsx
+++ b/frontend/src/routes/my/component/Follow.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+export default function Follow() {
+  //props로 id, 이름, 프사 받아오기
+  const [userName, setUserName] = useState("DogisCute");
+  const [profileImg, setProfileImg] = useState(
+    "https://i.namu.wiki/i/eZE2tbZyRnZq-oHCEprbnLd6F_yU0ZReQKV66QcwYXz9Ru-4OQ6ueDU84bcZRKDW3toounG6AqOLG_H23ifmdZqkKAZZ28AfmHXq0RmpJgMNA3yAan5j2rNOP0xacfeirE4FjMiemSIHtLTC8RKQ8w.webp"
+  );
+
+  return (
+    <div>
+      <div className="flex gap-[1rem]">
+        <img className="size-10 rounded-full" src={profileImg} />
+        <p className="text-sm mt-[0.7rem] ">{userName}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/my/component/FollowList.jsx
+++ b/frontend/src/routes/my/component/FollowList.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export default function Follow() {
+export default function FollowList() {
   //props로 id, 이름, 프사 받아오기
   const [userName, setUserName] = useState("DogisCute");
   const [profileImg, setProfileImg] = useState(


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
origin/gyeongjin -> main

### 변경 사항
navbar 및 제목 헤더 추가
사용자 프로필, 이름, 소개글 노출
팔로우/팔로잉 클릭 시 팔로우/팔로잉 목록 노출 기능
팔로우/팔로잉 클릭 시 페이지 이동 기능

### 테스트 결과
<img width="1512" alt="마이페이지" src="https://github.com/Typerproject/Frontend/assets/92127658/9e9ee61e-e4ce-48a3-9d68-3e65b2b83b9e">
