### PR TITLE
Yapyap withCredentials: true 쿠키 오류 수정 및 에디터 타입 수정

### DIFF
--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -6,6 +6,7 @@ export default class BaseApi {
     axios.defaults.withCredentials = true;
     this.fetcher = axios.create({
       baseURL: url,
+      withCredentials: true,
       headers: {
         "Content-Type": "application/json",
       },

--- a/frontend/src/api/postDetailAPI.ts
+++ b/frontend/src/api/postDetailAPI.ts
@@ -1,19 +1,31 @@
 // postDetail 관련 api..
 import BaseApi from "./axiosInstance";
+import { OutputData } from "@editorjs/editorjs";
 
 // 요청에 쓰일 인터페이스 정의 부분
 export interface IPostDetail {
-    _id: string;
-    writer: string;
-    // updated: Date;
-    // 글 내용 추가 필요
+  _id: string;
+  writer: string;
+  // updated: Date;
+  // 글 내용 추가 필요
 }
 
-export default class postDetailAPI extends BaseApi {
-    async getPostInfo(_id:string) {
-        const resp = await this.fetcher.post("/postInfo", {
-            id: _id,
-        });
-        return resp.data;
-    }
+export interface IAddPostBody {
+  title: string | null;
+  content: OutputData;
+  public: boolean;
+}
+
+export default class postAPI extends BaseApi {
+  async getPost(_id: string) {
+    const resp = await this.fetcher.post("/", {
+      params: { postId: _id },
+    });
+    return resp.data;
+  }
+
+  async addPost(body: IAddPostBody) {
+    const resp = await this.fetcher.post("/", body);
+    return resp.data;
+  }
 }

--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -9,7 +9,7 @@ const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
 export default function EditorPage() {
   const [isPublic, setPublic] = useState(true);
-  const [title, setTitle] = useState<string>("");
+  const [title, setTitle] = useState<string | null>(null);
   const [content, setContent] = useState<OutputData>();
 
   const changeVisibility = () => {
@@ -18,7 +18,11 @@ export default function EditorPage() {
 
   const publish = () => {
     if (!content?.blocks) {
-      console.log("데이터가 존재하지 않음");
+      alert("내용이 없습니다. 내용을 작성해주세요");
+      return;
+    }
+    if (title === null) {
+      alert("제목이 없습니다. 제목을 작성해주세요");
       return;
     }
 

--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -3,10 +3,13 @@ import Editor from "./component/Editor";
 import Timer from "./component/Timer";
 import { IoMdLock, IoMdUnlock } from "react-icons/io";
 import { OutputData } from "@editorjs/editorjs";
+import postAPI from "../../api/postDetailAPI";
+
+const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
 export default function EditorPage() {
   const [isPublic, setPublic] = useState(true);
-
+  const [title, setTitle] = useState<string>("");
   const [content, setContent] = useState<OutputData>();
 
   const changeVisibility = () => {
@@ -19,7 +22,11 @@ export default function EditorPage() {
       return;
     }
 
-    console.log(content);
+    service.addPost({
+      title: title,
+      content: content,
+      public: isPublic,
+    });
   };
 
   return (
@@ -32,6 +39,7 @@ export default function EditorPage() {
             className="block w-11/12 p-4 text-4xl mb-4"
             placeholder="제목을 입력해주세요"
             maxLength={25}
+            onChange={(e) => setTitle(e.target.value)}
           />
 
           <Timer />


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [X] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main

### 변경 사항
백엔드에 요청을 보낼 시 쿠키를 함께 보내기 위해서 axiosInstance에 withCredentials: true옵션을 추가했습니다.
이제 axiosInstance를 상속한 axios client는 모두 쿠키를 담아서 요청을 보냅니다.

에디터에서 저장할 때 title의 타입을 null로 받지 않던 부분을 수정했습니다.

에디터에서 출간을 누를 때 제목, 내용이 비어있는 경우 alert를 띄우면서 작성되지 않도록 했습니다.

