### PR TITLE
에디터 API 연결 및 postDetail 페이지 연결

### DIFF
--- a/frontend/src/api/postDetailAPI.ts
+++ b/frontend/src/api/postDetailAPI.ts
@@ -4,13 +4,20 @@ import { OutputData } from "@editorjs/editorjs";
 
 // 요청에 쓰일 인터페이스 정의 부분
 export interface IPostDetail {
-  _id: string;
-  writer: string;
-  // updated: Date;
-  // 글 내용 추가 필요
+  id: string;
+  title: string;
+  content: OutputData;
+  public: boolean;
+  writer: IPostWriter;
+  writedAt: Date;
+}
+export interface IPostWriter {
+  writerId: string;
+  name: string;
+  img: string;
 }
 
-export interface IAddPostBody {
+export interface IPostBody {
   title: string | null;
   content: OutputData;
   public: boolean;
@@ -18,13 +25,13 @@ export interface IAddPostBody {
 
 export default class postAPI extends BaseApi {
   async getPost(_id: string) {
-    const resp = await this.fetcher.post("/", {
+    const resp = await this.fetcher.get("/", {
       params: { postId: _id },
     });
     return resp.data;
   }
 
-  async addPost(body: IAddPostBody) {
+  async addPost(body: IPostBody) {
     const resp = await this.fetcher.post("/", body);
     return resp.data;
   }

--- a/frontend/src/main-router.tsx
+++ b/frontend/src/main-router.tsx
@@ -37,7 +37,7 @@ const routers = [
     // index: true
     children: [
       {
-        path: "",
+        path: ":id",
         element: <PostDetail />,
         index: true,
       },

--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -4,10 +4,13 @@ import Timer from "./component/Timer";
 import { IoMdLock, IoMdUnlock } from "react-icons/io";
 import { OutputData } from "@editorjs/editorjs";
 import postAPI from "../../api/postDetailAPI";
+import { useNavigate } from "react-router-dom";
 
 const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
 export default function EditorPage() {
+  const navigate = useNavigate();
+
   const [isPublic, setPublic] = useState(true);
   const [title, setTitle] = useState<string | null>(null);
   const [content, setContent] = useState<OutputData>();
@@ -16,7 +19,7 @@ export default function EditorPage() {
     setPublic(!isPublic);
   };
 
-  const publish = () => {
+  const publish = async () => {
     if (!content?.blocks) {
       alert("내용이 없습니다. 내용을 작성해주세요");
       return;
@@ -26,11 +29,13 @@ export default function EditorPage() {
       return;
     }
 
-    service.addPost({
+    const result = await service.addPost({
       title: title,
       content: content,
       public: isPublic,
     });
+
+    navigate(`/post/${result._id}`);
   };
 
   return (

--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -9,13 +9,11 @@ import { useNavigate } from "react-router-dom";
 const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
 export default function EditorPage() {
-  const navigate = useNavigate();
-
   const [isPublic, setPublic] = useState(true);
   const [title, setTitle] = useState<string | null>(null);
   const [content, setContent] = useState<OutputData>();
 
-  const navigate=useNavigate();
+  const navigate = useNavigate();
 
   const changeVisibility = () => {
     setPublic(!isPublic);
@@ -58,7 +56,9 @@ export default function EditorPage() {
           <Editor setContent={setContent} />
         </div>
         <footer className="bg-black h-14 sticky top-[100vh] flex items-center justify-between	px-16">
-          <p className="text-white text-xl" onClick={()=>navigate("/my")}>나가기</p>
+          <p className="text-white text-xl" onClick={() => navigate("/my")}>
+            나가기
+          </p>
 
           <div className="flex items-center w-[10%] justify-between	">
             {isPublic ? (

--- a/frontend/src/routes/editor/component/blockTools/chart/ChartBlock.tsx
+++ b/frontend/src/routes/editor/component/blockTools/chart/ChartBlock.tsx
@@ -37,7 +37,12 @@ export class ChartBLock {
     };
   }
 
+  static get isReadOnlySupported() {
+    return true;
+  }
+
   render() {
+    console.log(this.data);
     const rootNode = document.createElement("div");
     this.nodes = rootNode;
 

--- a/frontend/src/routes/editor/component/blockTools/news/NewsBlock.tsx
+++ b/frontend/src/routes/editor/component/blockTools/news/NewsBlock.tsx
@@ -14,11 +14,10 @@ export interface INewsData {
 }
 
 export class NewsBlock {
-
   nodes: HTMLElement | null;
   data: INewsData;
 
-  constructor({data}: NewsBlockData) {
+  constructor({ data }: NewsBlockData) {
     this.data = data;
     this.nodes = null;
   }
@@ -35,22 +34,22 @@ export class NewsBlock {
   }
 
   render() {
-    const setNewsData = (data :INewsData):void => {
+    const setNewsData = (data: INewsData): void => {
       this.data = data;
     };
 
     const rootNode = document.createElement("div");
     this.nodes = rootNode;
 
-    CreateDOM.createRoot(rootNode).render(<StockNews newsData={this.data} setNewsData={setNewsData} />);
+    CreateDOM.createRoot(rootNode).render(
+      <StockNews newsData={this.data} setNewsData={setNewsData} />
+    );
 
     return rootNode;
   }
 
   save() {
     // console.log(this.data)
-    return {
-      data: this.data,
-    }
+    return this.data;
   }
 }

--- a/frontend/src/routes/postDetail/PostDetailPage.tsx
+++ b/frontend/src/routes/postDetail/PostDetailPage.tsx
@@ -1,7 +1,6 @@
-import PostContent from "./component/PostContent"
+import PostContent from "./component/PostContent";
 import CommentList from "./component/CommentList";
 import InputComment from "./component/InputComment";
-// type Props = {}
 
 export default function PostDetail() {
   return (
@@ -10,5 +9,5 @@ export default function PostDetail() {
       <InputComment />
       <CommentList />
     </div>
-  )
+  );
 }

--- a/frontend/src/routes/postDetail/component/PostContent.tsx
+++ b/frontend/src/routes/postDetail/component/PostContent.tsx
@@ -1,12 +1,42 @@
 import WriterInfo from "./WriterInfo";
 import { FaHeart } from "react-icons/fa6"; // 채워진 하트
 import { FaRegHeart } from "react-icons/fa6"; // 빈 하트
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ViewEditor from "./ViewEditor";
+import postAPI, { IPostWriter, IPostDetail } from "../../../api/postDetailAPI";
+import { useParams } from "react-router-dom";
+import { OutputData } from "@editorjs/editorjs";
 
-// type Props = {}
-
+const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 export default function PostContent() {
+  const [title, setTitle] = useState<string>("title");
+  const [writer, setWriter] = useState<IPostWriter>();
+  const [outputData, setOutputData] = useState<OutputData>();
+  const [writedAt, setWritedAt] = useState<string>();
+
+  const { id } = useParams<{ id: string }>() as { id: string };
+  useEffect(() => {
+    service.getPost(id).then((res: IPostDetail) => {
+      console.log(res);
+      setTitle(res.title);
+      setWriter(res.writer);
+      setOutputData(res.content);
+
+      const date = new Date(res.writedAt);
+      const formattedDate = date.toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+      const formattedTime = date.toLocaleTimeString("ko-KR", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false, // 24시간 형식
+      });
+      setWritedAt(`${formattedDate} ${formattedTime}`);
+    });
+  }, [id]);
+
   const [validHeart, setValidHeart] = useState(false);
 
   function handleLike() {
@@ -17,15 +47,15 @@ export default function PostContent() {
   return (
     <div className="w-full h-full min-h-70 rounded-[10px] shadow-[0_0_8px_5px] shadow-gray-200 p-[2rem]">
       {/* 글 제목, 날짜, 글쓴이 기본 정보 */}
-      <h1 className="text-3xl	font-bold">게시글 상세 페이지</h1>
-      <p className="text-gray-400 my-[10px]">2024년 06월 07일 13:23</p>
-      <WriterInfo />
+      <h1 className="text-3xl	font-bold">{title}</h1>
+      <p className="text-gray-400 my-[10px]">{writedAt}</p>
+      {writer && <WriterInfo writer={writer} />}
 
       {/* divider */}
       <div className="h-[0.5px] my-[0.75rem] w-full bg-current"></div>
 
       {/* 글 내용 */}
-      <ViewEditor />
+      {outputData && <ViewEditor outPutData={outputData} />}
 
       <div className="flex flex-row-reverse items-center gap-[1rem]">
         <p>123</p>

--- a/frontend/src/routes/postDetail/component/ViewEditor.tsx
+++ b/frontend/src/routes/postDetail/component/ViewEditor.tsx
@@ -1,51 +1,22 @@
 // import React from 'react'
-import EditorJS from "@editorjs/editorjs";
+import EditorJS, { OutputData } from "@editorjs/editorjs";
 import Header from "@editorjs/header";
 import { NewsBlock } from "../../editor/component/blockTools/news/NewsBlock";
+import { ChartBLock } from "../../editor/component/blockTools/chart/ChartBlock";
 
-const dummyData = {
-  time: 1718069579642,
-  blocks: [
-    {
-      id: "l98dyx3yjb",
-      type: "header",
-      data: {
-        text: "Header예시",
-        level: 1,
-      },
-    },
-    {
-      id: "1yKeXKxN7-",
-      type: "header",
-      data: {
-        text: "header level3",
-        level: 3,
-      },
-    },
-    {
-      id: "lasjflasjfl",
-      type: "news",
-      data: {
-        detail:
-          "중국 최대 통신장비업체 화웨이가 9월 출시 예정인 인공지능(AI) 칩 성능이 미국 엔비디아의 최신작 H200에 필적할 것으로 보인다고 중국시보 등 대만언론이 12일 보도했다. 보도에 따르면 한 소식통은 화웨이가 7㎚",
-        imgUrl:
-          "https://imgnews.pstatic.net/image/011/2024/06/12/0004352292_001_20240612162612344.png?type=w800",
-        newsUrl: "https://n.news.naver.com/mnews/article/011/0004352292",
-        title:
-          '대만언론 "곧 출시되는 화웨이 AI칩, 엔비디아 최신작 H200에 필적"',
-      },
-    },
-  ],
+type props = {
+  outPutData: OutputData;
 };
 
-export default function ViewEditor() {
+export default function ViewEditor({ outPutData }: props) {
   new EditorJS({
     holder: "viewEditor",
     readOnly: true,
-    data: dummyData,
+    data: outPutData,
     tools: {
       header: Header,
       news: NewsBlock,
+      charts: ChartBLock,
     },
   });
 

--- a/frontend/src/routes/postDetail/component/WriterInfo.tsx
+++ b/frontend/src/routes/postDetail/component/WriterInfo.tsx
@@ -1,19 +1,22 @@
 // type Props = {}
 import { useNavigate } from "react-router-dom";
+import { IPostWriter } from "../../../api/postDetailAPI";
 
-export default function WriterInfo() {
+type Props = {
+  writer: IPostWriter;
+};
+
+export default function WriterInfo({ writer }: Props) {
   const navigate = useNavigate();
 
   return (
     <div className="flex items-center gap-[0.75rem] py-[0.75rem]">
       <div
-      className="flex items-center gap-[0.75rem] cursor-pointer"
-       onClick={() => navigate("/my")}>
-        <img
-          className="w-[40px] rounded-full"
-          src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU"
-        />
-        <p className="text-sm">경진씨</p>
+        className="flex items-center gap-[0.75rem] cursor-pointer"
+        onClick={() => navigate(`/my/${writer.writerId}`)}
+      >
+        <img className="w-[40px] rounded-full" src={writer.img} />
+        <p className="text-sm">{writer.name}</p>
       </div>
       <button className="text-xs border-[1px] bg-black text-white rounded-full border-black text-sm px-[0.7rem] py-[0.3rem] hover:bg-white hover:text-black duration-300">
         팔로우


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> dev

### 변경 사항
드디어 에디터가 정상적으로 동작합니다.
출간을 누르면 백엔드에 POST요청을 보내서 데이터베이스에 저장하고 postDetail 페이지로 리다이렉트 합니다.
기존에 Mock 데이터로 랜더링 되던 postDetail 페이지를 실제 url에 해당하는 데이터로 바꿨습니다.
추가적으로 news 블록의 save() 리턴 값이 한번 더 랩핑 되던 문제를 해결했습니다.


### 테스트 결과
![image](https://github.com/Typerproject/Frontend/assets/99272057/c8d1a2e6-6af5-4d3d-b9e6-726def50e289)

