### PR TITLE
fix: 에디터 페이지 레이아웃 변경

### DIFF
--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Editor from "./component/Editor";
 import Timer from "./component/Timer";
 import { IoMdLock, IoMdUnlock } from "react-icons/io";
@@ -12,6 +12,7 @@ export default function EditorPage() {
   const [isPublic, setPublic] = useState(true);
   const [title, setTitle] = useState<string | null>(null);
   const [content, setContent] = useState<OutputData>();
+  const holder = useRef<HTMLDivElement>(null);
 
   const navigate = useNavigate();
 
@@ -40,48 +41,51 @@ export default function EditorPage() {
 
   return (
     <>
-      <div className="h-dvh">
-        <nav className="bg-black h-4" />
-        <div className="flex flex-col items-center">
-          <input
-            type="text"
-            className="block w-11/12 p-4 text-4xl mb-4"
-            placeholder="제목을 입력해주세요"
-            maxLength={25}
-            onChange={(e) => setTitle(e.target.value)}
-          />
+      <nav className="fixed top-0 bg-black h-4 w-full" />
+      <div className="flex flex-col items-center overflow-y-scroll h-screen">
+        <input
+          type="text"
+          className="block w-[95%] p-4 text-4xl"
+          placeholder="제목을 입력해주세요"
+          maxLength={25}
+          onChange={(e) => setTitle(e.target.value)}
+        />
 
-          <Timer />
+        <Timer />
 
-          <Editor setContent={setContent} />
+        <div
+          className="w-[98%] mt-2 mb-5 min-h-dv min-h-[80%] h-fit"
+          ref={holder}
+        >
+          <Editor setContent={setContent} holder={holder} />
         </div>
-        <footer className="bg-black h-14 sticky top-[100vh] flex items-center justify-between	px-16">
-          <p className="text-white text-xl" onClick={() => navigate("/my")}>
-            나가기
-          </p>
-
-          <div className="flex items-center w-[10%] justify-between	">
-            {isPublic ? (
-              <IoMdUnlock
-                color={"white"}
-                size={30}
-                onClick={changeVisibility}
-                title="공개"
-              />
-            ) : (
-              <IoMdLock
-                color={"white"}
-                size={30}
-                onClick={changeVisibility}
-                title="비공개"
-              />
-            )}
-            <p className="text-white text-xl" onClick={publish}>
-              출간
-            </p>
-          </div>
-        </footer>
       </div>
+      <footer className="fixed bg-black h-14 bottom-[0px] flex items-center justify-between	px-16 w-full">
+        <p className="text-white text-xl" onClick={() => navigate("/my")}>
+          나가기
+        </p>
+
+        <div className="flex items-center w-[10%] justify-between	">
+          {isPublic ? (
+            <IoMdUnlock
+              color={"white"}
+              size={30}
+              onClick={changeVisibility}
+              title="공개"
+            />
+          ) : (
+            <IoMdLock
+              color={"white"}
+              size={30}
+              onClick={changeVisibility}
+              title="비공개"
+            />
+          )}
+          <p className="text-white text-xl" onClick={publish}>
+            출간
+          </p>
+        </div>
+      </footer>
     </>
   );
 }

--- a/frontend/src/routes/editor/component/Editor.tsx
+++ b/frontend/src/routes/editor/component/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, RefObject } from "react";
 import EditorJS from "@editorjs/editorjs";
 import "../../../index.css";
 import Header from "@editorjs/header";
@@ -10,9 +10,10 @@ import { ReportBlock } from "./blockTools/Report/ReportBlock";
 
 type Props = {
   setContent: (value: OutputData) => void;
+  holder: RefObject<HTMLDivElement>;
 };
 
-export default function Editor({ setContent }: Props) {
+export default function Editor({ setContent, holder }: Props) {
   const ejInstance = useRef<EditorJS | null>(null);
 
   const initEditor = () => {
@@ -25,7 +26,6 @@ export default function Editor({ setContent }: Props) {
       onChange: async () => {
         setContent(await editor.save());
       },
-      minHeight: 400,
       tools: {
         header: {
           class: Header as unknown as ToolConstructable,
@@ -38,10 +38,16 @@ export default function Editor({ setContent }: Props) {
         charts: ChartBLock,
         news: NewsBlock,
         Report: ReportBlock,
-        finance: FinanceBlock
-
+        finance: FinanceBlock,
       },
+      autofocus: true,
     });
+
+    if (holder.current) {
+      holder.current.addEventListener("click", () => {
+        editor.focus();
+      });
+    }
   };
 
   useEffect(() => {
@@ -58,7 +64,7 @@ export default function Editor({ setContent }: Props) {
   return (
     <div
       id="editorjs"
-      className="w-11/12 mt-2 border-solid border-2 rounded-2xl shadow-md mb-5 overflow-y-auto max-h-[63vh]"
+      className="border-solid border-x-2 border-slate-300 min-h-[100%]"
     ></div>
   );
 }


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main

### 변경 사항
에디터 페이지의 레이아웃을 변경했습니다.
에디터가 한정된 높이에 갇혀있는게 답답해서 줄 수가 늘어나는 경우 확장되면서 전체적으로 무한 스크롤이 적용되도록 수정했습니다.


### 테스트 결과
![image](https://github.com/Typerproject/Frontend/assets/99272057/092f718c-9c36-4711-adbf-16e1617b597d)
