### PR TITLE
feat: 마이페이지 게시글 미리보기 유저 정보로 설정

### DIFF
--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -57,7 +57,7 @@ export default function Post({ id }: { id: string | undefined }) {
     <div className="w-full p-[2rem]">
       <div className="cursor-pointer ">
         {/* 날짜, 글쓴이 기본 정보 */}
-        <div className="flex gap-[17rem] items-center">
+        <div className="flex gap-[17rem] items-center mb-[1rem]">
           <div
             onClick={() => navigate("/my")}
             className="flex gap-[0.5rem] items-center"

--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -1,18 +1,50 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import userAPI, { IFollowerInfo, IUserInfo } from "../../api/userAPI";
 import { FaHeart } from "react-icons/fa6"; // 채워진 하트
 import { FaRegHeart } from "react-icons/fa6"; // 빈 하트
 import { FaRegComment } from "react-icons/fa";
 
-export default function Post() {
+const service = new userAPI(import.meta.env.VITE_BASE_URI);
+
+export default function Post({ id }: { id: string | undefined }) {
   const navigate = useNavigate();
-  //게시글 아이디를 전달받아서 api호출을 통해 게시글 정보를 받아옴
+
+  const [userInfo, setUserInfo] = useState<IUserInfo | null>(null);
+
+  //유저 정보 가져오기
+  useEffect(() => {
+    if (id) {
+      console.log("파라미터 잘 가져와 지나?", id);
+
+      // 유저 정보 겟또다제
+      service
+        .getUserInfo(id)
+        .then((data) => {
+          console.log("마페 유저", data);
+          setUserInfo(data);
+        })
+        .catch((err) => {
+          console.error("마페 유저", err);
+        });
+      console.log("post에 띄울 유저 정보 가져오기 성공");
+    } else {
+      console.log("post에 띄울 유저 정보 가져오기 실패");
+    }
+  }, [id]);
+
+  //유저의 정보
+  const userName: string | undefined = userInfo?.nickname;
+  const userProfile: string | undefined = userInfo?.profile;
+
+  //마아페이지 아이디를 전달받아서 api호출을 통해 게시글 정보를 받아옴
   const title: string = "테스트 게시글 입니다.";
   const date: string = "2024-06-12 15:24:32";
-  const userName: string = "CatisCute";
   const like: number = 231;
   const content: string = "내용 세 줄 요약해서 출력";
   const comment: number = 10;
+  const picture: string =
+    "https://src.hidoc.co.kr/image/lib/2022/5/12/1652337370806_0.jpg"; //미리보기 사진
 
   const [validHeart, setValidHeart] = useState(false);
 
@@ -30,19 +62,21 @@ export default function Post() {
             onClick={() => navigate("/my")}
             className="flex gap-[0.5rem] items-center"
           >
-            <img
-              className="w-[40px] rounded-full"
-              src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD68cSMsrBiEs6YloK8MVPO1DlJ7LqKt4OxT7ioMJn7xh-1iqPV0FVFjvTA7Cvlv-Y9Yc&usqp=CAU"
-            />
+            <img className="w-[40px] rounded-full" src={userProfile} />
             <p className="text-sm">{userName}</p>
           </div>
           <p className="text-sm text-gray-400">{date}</p>
         </div>
 
         {/* 글 내용 */}
-        <div onClick={() => navigate("/post")}>
-          <div className="text-4xl mt-[1rem]">{title}</div>
-          <p className="text-base py-[2rem] text-gray-500">{content}</p>
+        <div className="flex">
+          <div className="flex-1" onClick={() => navigate("/post")}>
+            <div className="text-4xl mt-[1rem]">{title}</div>
+            <p className="text-base py-[2rem] text-gray-500">{content}</p>
+          </div>
+          <div className="flex-none">
+            <img className="w-[200px]" src={picture} />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/routes/my/MyPage.tsx
+++ b/frontend/src/routes/my/MyPage.tsx
@@ -274,8 +274,7 @@ export default function MyPage() {
           <p>{userInfo?.nickname}'s Typer</p>
           <div>
             {/*가져온 글 목록을 map돌면서 출력*/}
-            <Post />
-            <Post />
+            <Post id={id} />
           </div>
         </div>
 


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
gyeongjin -> main

### 변경 사항
- 마이페이지 게시글 미리보기 프로필 이미지 및 이름 유저 정보로 설정했습니다.
- 게시글 미리보기 글과 함께 오른쪽에 이미지 같이 뜨게 구현했습니다.

### 테스트 결과
<img width="1512" alt="게시글미리보기" src="https://github.com/Typerproject/Frontend/assets/92127658/49d0272f-0331-4fec-8fb4-e18b949f5fac">

