### PR TITLE
✨ feat: 401에러 반환 받을 시 로그인 모달창이 뜨도록 기능 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 import store from "./store";
 import { PersistGate } from "redux-persist/integration/react";
 import { persistStore } from "redux-persist";
+import LoginModalContainer from "./components/login/LoginModalContainer";
 // import { persistStore } from "redux-persist";
 
 export const persistor = persistStore(store);
@@ -13,6 +14,7 @@ function App() {
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
         <RouterProvider router={MainRouter} />
+        <LoginModalContainer />
       </PersistGate>
     </Provider>
   );

--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -1,4 +1,7 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { response } from "express";
+import store from "../store";
+import { openLoginModal } from "../store/reducers/auth";
 
 export default class BaseApi {
   fetcher;
@@ -12,5 +15,17 @@ export default class BaseApi {
       },
     });
     // token 관련 interceptors 필요 시 코드 추가하면 될듯
+
+    // 인터셉터 설정
+    this.fetcher.interceptors.response.use(
+      (response: AxiosResponse) => response,
+      (error: AxiosError) => {
+        if (error.response && error.response.status === 401) {
+          // 401 에러인 경우 Redux 액션 디스패치
+          store.dispatch(openLoginModal());
+        }
+        return Promise.reject(error);
+      }
+    );
   }
 }

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -56,12 +56,14 @@ export default function Navbar() {
         <div>
           {userInfo._id ? (
             <NavLink to="/editor">
-              <p className="text-[#E5E5E5] text-xl hover:text-white">Write</p>
+              <p className="text-[#E5E5E5] text-xl hover:text-white cursor-pointer">
+                Write
+              </p>
             </NavLink>
           ) : (
             <p
               onClick={handleLoginClick}
-              className="text-[#E5E5E5] text-xl hover:text-white"
+              className="text-[#E5E5E5] text-xl hover:text-white cursor-pointer"
             >
               Login
             </p>
@@ -71,7 +73,7 @@ export default function Navbar() {
           {userInfo.profile ? (
             <img
               onClick={handleToggleMenu}
-              className="w-[40px] rounded-full"
+              className="w-[40px] rounded-full cursor-pointer transition duration-200 ease-in-out transform hover:opacity-80"
               src={userInfo.profile}
             />
           ) : (
@@ -83,7 +85,7 @@ export default function Navbar() {
                 <li className="px-4 py-2 hover:bg-gray-100">
                   <NavLink
                     to={`/my/${userInfo._id}`}
-                    className="text-black no-underline"
+                    className="text-black no-underline cursor-pointer"
                   >
                     My page
                   </NavLink>

--- a/frontend/src/components/login/LoginModal.tsx
+++ b/frontend/src/components/login/LoginModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Modal from "react-modal";
-import { GoChevronLeft } from "react-icons/go";
+import { GrFormClose } from "react-icons/gr";
 import kakaoButton from "../../assets/loginButton.png";
 
 Modal.setAppElement("#root");
@@ -21,7 +21,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onRequestClose }) => {
 
   return (
     <Modal
-      className="flex flex-col justify-between items-center text-center mx-auto my-40 w-[380px] h-[500px] relative mb-0 bg-white rounded-lg shadow-2xl"
+      className="flex flex-col justify-between items-center text-center mx-auto my-40 w-[380px] h-[500px] relative mb-0 bg-white rounded-[22px] shadow-2xl"
       isOpen={isOpen}
       onRequestClose={onRequestClose}
     >
@@ -30,7 +30,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onRequestClose }) => {
         className="w-10 h-10 bg-no-repeat bg-center bg-cover bg-opacity-50 cursor-pointer border-none top-0 left-0 z-50 mt-0 mr-80"
         onClick={onRequestClose}
       >
-        <GoChevronLeft className="w-8 h-8 text-gray-500 mt-3" />
+        <GrFormClose className="w-8 h-8 text-gray-400 mt-3 ml-1" />
       </button>
 
       <div className="flex flex-col justify-center items-center pt-14">
@@ -65,12 +65,12 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onRequestClose }) => {
 
       {/* 서비스 미리보기 */}
       <div className="w-[120px] h-[19px] pb-10">
-        <a
+        <button
           className="text-black text-sm underline cursor-pointer"
           style={{ textUnderlineOffset: "5px" }}
         >
           서비스 미리보기
-        </a>
+        </button>
       </div>
     </Modal>
   );

--- a/frontend/src/components/login/LoginModalContainer.tsx
+++ b/frontend/src/components/login/LoginModalContainer.tsx
@@ -1,0 +1,19 @@
+import { useAppDispatch, useAppSelector, RootState } from "../../store";
+import { closeLoginModal } from "../../store/reducers/auth";
+import LoginModal from "../../components/login/LoginModal";
+
+const LoginModalContainer: React.FC = () => {
+  const isLoginModalOpen = useAppSelector(
+    (state: RootState) => state.loginModal.isLoginModalOpen
+  );
+  const dispatch = useAppDispatch();
+
+  return (
+    <LoginModal
+      isOpen={isLoginModalOpen}
+      onRequestClose={() => dispatch(closeLoginModal())}
+    />
+  );
+};
+
+export default LoginModalContainer;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,5 +1,6 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import userReducer from "./reducers/user";
+import loginModalReducer from "./reducers/auth";
 import {
   persistReducer,
   // persistStore
@@ -9,6 +10,7 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 
 const reducers = combineReducers({
   user: userReducer,
+  loginModal: loginModalReducer,
 });
 
 const persistConfig = {

--- a/frontend/src/store/reducers/auth.ts
+++ b/frontend/src/store/reducers/auth.ts
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+interface LoginModalState {
+  isLoginModalOpen: boolean;
+}
+
+const initialState: LoginModalState = {
+  isLoginModalOpen: false,
+};
+
+const loginModalSlice = createSlice({
+  name: "loginModal",
+  initialState,
+  reducers: {
+    openLoginModal(state) {
+      state.isLoginModalOpen = true;
+    },
+    closeLoginModal(state) {
+      state.isLoginModalOpen = false;
+    },
+  },
+});
+
+export const { openLoginModal, closeLoginModal } = loginModalSlice.actions;
+export default loginModalSlice.reducer;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
jaehyeon -> main

### 변경 사항
서버로부터 401에러를 받게 되면 그냥 에러만 받고 끝이 아니라, 로그인 모달창이 뜨도록 구현했습니다.

### 테스트 결과
로그인을 하지 않은 상태에서 유저를 팔로워 하려고 할 때, 401에러를 받고, 모달창을 띄웁니다.
![image](https://github.com/Typerproject/Frontend/assets/81346079/bc7aa6bf-e4d2-431e-8bc8-64e07f4fd483)

