### PR TITLE
Chart 블록 모달 관련 오류 수정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@editorjs/editorjs": "^2.29.1",
         "@editorjs/header": "^2.8.1",
+        "@editorjs/paragraph": "^2.11.5",
         "@reduxjs/toolkit": "^2.2.5",
         "@types/editorjs__header": "^2.6.3",
         "apexcharts": "^3.49.1",
@@ -451,6 +452,19 @@
       "dependencies": {
         "@codexteam/icons": "^0.0.5"
       }
+    },
+    "node_modules/@editorjs/paragraph": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@editorjs/paragraph/-/paragraph-2.11.5.tgz",
+      "integrity": "sha512-ZcUKnVOoFPuMdVJJXMo2odmsjxeZQOUxmOwOiZktRuFkRDMq9qCqkmzqE1BH5VR6YyyMLKV4ZBEwedwggDH8iA==",
+      "dependencies": {
+        "@codexteam/icons": "^0.0.4"
+      }
+    },
+    "node_modules/@editorjs/paragraph/node_modules/@codexteam/icons": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@codexteam/icons/-/icons-0.0.4.tgz",
+      "integrity": "sha512-V8N/TY2TGyas4wLrPIFq7bcow68b3gu8DfDt1+rrHPtXxcexadKauRJL6eQgfG7Z0LCrN4boLRawR4S9gjIh/Q=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@editorjs/editorjs": "^2.29.1",
     "@editorjs/header": "^2.8.1",
+    "@editorjs/paragraph": "^2.11.5",
     "@reduxjs/toolkit": "^2.2.5",
     "@types/editorjs__header": "^2.6.3",
     "apexcharts": "^3.49.1",

--- a/frontend/src/api/editorAPI.ts
+++ b/frontend/src/api/editorAPI.ts
@@ -32,4 +32,15 @@ export default class editorAPI extends BaseApi {
 
     return resp.data;
   }
+
+  async getCorpCode(name: string, page: number) {
+    const resp = await this.fetcher.get("/disclosure/corpCode", {
+      params: {
+        name: name,
+        page: page,
+      },
+    });
+
+    return resp.data;
+  }
 }

--- a/frontend/src/routes/editor/component/Editor.tsx
+++ b/frontend/src/routes/editor/component/Editor.tsx
@@ -7,6 +7,8 @@ import { ChartBLock } from "./blockTools/chart/ChartBlock";
 import { NewsBlock } from "./blockTools/news/NewsBlock";
 import { FinanceBlock } from "./blockTools/finance/FinanceBlock";
 import { ReportBlock } from "./blockTools/Report/ReportBlock";
+import { DisclosureBlock } from "./blockTools/disclosure/DisclosureBlock";
+
 type Props = {
   setContent: (value: OutputData) => void;
 };
@@ -35,7 +37,8 @@ export default function Editor({ setContent }: Props) {
         charts: ChartBLock,
         news: NewsBlock,
         Report: ReportBlock,
-        finance: FinanceBlock
+        finance: FinanceBlock,
+        disclosure: DisclosureBlock,
       },
     });
   };

--- a/frontend/src/routes/editor/component/Editor.tsx
+++ b/frontend/src/routes/editor/component/Editor.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from "react";
 import EditorJS from "@editorjs/editorjs";
 import "../../../index.css";
 import Header from "@editorjs/header";
+import Paragraph from "@editorjs/paragraph";
 import { type ToolConstructable, OutputData } from "@editorjs/editorjs";
 import { ChartBLock } from "./blockTools/chart/ChartBlock";
 import { NewsBlock } from "./blockTools/news/NewsBlock";
@@ -39,6 +40,12 @@ export default function Editor({ setContent }: Props) {
         Report: ReportBlock,
         finance: FinanceBlock,
         disclosure: DisclosureBlock,
+        paragraph: {
+          class: Paragraph,
+          config: {
+            preserveBlank: true,
+          },
+        },
       },
     });
   };

--- a/frontend/src/routes/editor/component/blockTools/chart/Chart.tsx
+++ b/frontend/src/routes/editor/component/blockTools/chart/Chart.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactApexChart from "react-apexcharts";
+import { stockResp } from "./ChartBlock";
 
 // 날짜 포맷 변환 함수 (예시)
 function formatDate(dateStr: string) {
@@ -9,13 +10,17 @@ function formatDate(dateStr: string) {
   return `${year}-${month}-${day}`;
 }
 
-function JsonChartTest({ stockData }:any) {
-  if (!stockData) {
+interface chartProps {
+  stockData: stockResp;
+}
+
+function JsonChartTest({ stockData }: chartProps) {
+  if (Object.keys(stockData).length === 0) {
     return <div>No data available</div>;
   }
 
   const formattedDataForCandle = stockData.data
-    .map((item:any) => {
+    .map((item: any) => {
       const open = Number(item.open);
       const high = Number(item.high);
       const low = Number(item.low);
@@ -32,7 +37,7 @@ function JsonChartTest({ stockData }:any) {
         y: [open, high, low, close],
       };
     })
-    .filter((data:any) => data !== null); // 유효하지 않은 데이터를 제거
+    .filter((data: any) => data !== null); // 유효하지 않은 데이터를 제거
 
   const series = [
     {

--- a/frontend/src/routes/editor/component/blockTools/disclosure/DisclosureBlock.tsx
+++ b/frontend/src/routes/editor/component/blockTools/disclosure/DisclosureBlock.tsx
@@ -1,0 +1,39 @@
+import CreateDOM from "react-dom/client";
+import DisclosureModal from "./DisclosureModal";
+
+export class DisclosureBlock {
+  nodes: HTMLElement | null;
+  data: any;
+
+  constructor({ data }: any) {
+    this.data = data;
+    this.nodes = null;
+  }
+
+  static get toolbox() {
+    return {
+      title: "disclosure",
+      icon: "<svg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24'><path d='m19,0h-9c-2.757,0-5,2.243-5,5v1h-.5c-2.481,0-4.5,2.019-4.5,4.5v10c0,1.929,1.569,3.499,3.499,3.5h15.501c2.757,0,5-2.243,5-5V5c0-2.757-2.243-5-5-5ZM5,20.5c0,.827-.673,1.5-1.5,1.5s-1.5-.673-1.5-1.5v-10c0-1.378,1.122-2.5,2.5-2.5h.5v12.5Zm17-1.5c0,1.654-1.346,3-3,3H6.662c.216-.455.338-.963.338-1.5V5c0-1.654,1.346-3,3-3h9c1.654,0,3,1.346,3,3v14Zm-2-12c0,.552-.448,1-1,1h-3c-.552,0-1-.448-1-1s.448-1,1-1h3c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1ZM9,7v-2c0-.552.448-1,1-1h2c.552,0,1,.448,1,1v2c0,.552-.448,1-1,1h-2c-.552,0-1-.448-1-1Z'/></svg>",
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  render() {
+    const rootNode = document.createElement("div");
+    this.nodes = rootNode;
+
+    CreateDOM.createRoot(rootNode).render(<DisclosureModal></DisclosureModal>);
+    document.getElementById("root").appendChild(rootNode);
+
+    console.log(rootNode);
+
+    return document.createElement("div");
+  }
+
+  save() {
+    return this.data;
+  }
+}

--- a/frontend/src/routes/editor/component/blockTools/disclosure/DisclosureModal.tsx
+++ b/frontend/src/routes/editor/component/blockTools/disclosure/DisclosureModal.tsx
@@ -1,0 +1,133 @@
+import { useRef, useState } from "react";
+import editorAPI from "../../../../../api/editorAPI";
+
+interface corpCode {
+  _id: string;
+  corpName: string;
+  corpCode: string;
+}
+
+const service = new editorAPI(import.meta.env.VITE_SERVER_EDITOR_API_URI);
+
+export default function DisclosureModal() {
+  const searchResult = useRef<corpCode[]>([]);
+  const [searchName, setSearchName] = useState<string>("");
+  const [list, setList] = useState<corpCode[]>([]);
+  const [page, setPage] = useState<number>(2);
+  const [isMore, setMore] = useState<boolean>(false);
+  const [show, setShow] = useState<boolean>(true);
+
+  const nameChange = async () => {
+    searchResult.current.length = 0;
+    setPage(2);
+    const res = await service.getCorpCode(searchName, 1);
+    searchResult.current.push(...res.result);
+    setList([...searchResult.current]);
+    if (page < res.totalPages) {
+      setMore(true);
+    } else {
+      setMore(false);
+    }
+  };
+
+  const searchMore = async () => {
+    const res = await service.getCorpCode(searchName, page);
+    searchResult.current.push(...res.result);
+    setList([...searchResult.current]);
+    setPage(page + 1);
+    if (page < res.totalPages) {
+      setMore(true);
+    } else {
+      setMore(false);
+    }
+  };
+  const handleClose = () => setShow(false);
+
+  return (
+    <>
+      {show && (
+        <div className="fixed inset-0 flex items-center justify-center z-50 min-h-[1vh]">
+          <div className="fixed inset-0 bg-black opacity-50"></div>
+          <div className="bg-white rounded-lg shadow-lg overflow-hidden w-full max-w-md mx-2 z-10">
+            <div className="flex justify-between items-center p-4 border-b border-gray-200">
+              <h2 className="text-lg font-medium">공시를 조회할 기업 선택</h2>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => {
+                  handleClose();
+                }}
+              >
+                <svg
+                  className="h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className="px-4">
+              <label
+                htmlFor="default-search"
+                className="mb-2 text-sm font-medium text-gray-900 sr-only"
+              >
+                Search
+              </label>
+              <div className="relative">
+                <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none"></div>
+                <input
+                  type="search"
+                  id="default-search"
+                  className="block w-full p-4 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="검색할 기업 이름 입력"
+                  required
+                  onChange={(e) => {
+                    setSearchName(e.target.value);
+                  }}
+                />
+                <button
+                  className="text-white absolute end-2.5 bottom-4 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 "
+                  onClick={() => {
+                    nameChange();
+                  }}
+                >
+                  Search
+                </button>
+              </div>
+            </div>
+
+            <div className="min-h-[50vw] max-h-[40vw] overflow-y-scroll m-3">
+              {list.map((ele, idx) => {
+                return <div key={idx}>{ele.corpName + " " + ele.corpCode}</div>;
+              })}
+            </div>
+            {isMore && (
+              <div
+                onClick={() => {
+                  searchMore();
+                }}
+              >
+                데이터가 더 있음
+              </div>
+            )}
+
+            {/* <div className="flex justify-end p-4 border-t border-gray-200">
+            <button className="bg-gray-500 text-white px-4 py-2 rounded mr-2">
+              닫기
+            </button>
+            <button className="bg-blue-500 text-white px-4 py-2 rounded">
+              차트 그리기
+            </button>
+          </div> */}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [X] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap-chart-refactoring => main

### 변경 사항
에디터에서 Chart블록을 생성하는 모달 창을 완료하지 않고 닫았을 때 데이터가 채워지지 않은 블록이 그대로 유지되면서 게시글이 저장되면 뷰어에서 모달창이 뜨는 현상을 수정했습니다.

추가적으로 빈 Paragraph블록도 save() 메소드 호출에 저장되도록 해 줄 바꿈 내용이 함께 저장되도록 했습니다.


### 테스트 결과
![image](https://github.com/Typerproject/Frontend/assets/99272057/2b6b9955-9c82-43ff-99c0-37d8e907b8a8)
뷰어화면에서 공백 라인이 그대로 유지되는 모습입니다.