### PR TITLE
이미지 복사 붙여넣기 툴 추가!

### DIFF
--- a/frontend/src/routes/editor/component/Editor.tsx
+++ b/frontend/src/routes/editor/component/Editor.tsx
@@ -1,20 +1,21 @@
 import React, { useRef, useEffect } from "react";
 import EditorJS from "@editorjs/editorjs";
-import "../../../index.css";
 import Header from "@editorjs/header";
-import Paragraph from "@editorjs/paragraph";
-import { type ToolConstructable, OutputData } from "@editorjs/editorjs";
 import { ChartBLock } from "./blockTools/chart/ChartBlock";
 import { NewsBlock } from "./blockTools/news/NewsBlock";
 import { FinanceBlock } from "./blockTools/finance/FinanceBlock";
 import { ReportBlock } from "./blockTools/Report/ReportBlock";
+import { type ToolConstructable, OutputData } from "@editorjs/editorjs";
 import { DisclosureBlock } from "./blockTools/disclosure/DisclosureBlock";
+import { ImageBlock } from "./blockTools/image/ImageBlock";
 
 type Props = {
   setContent: (value: OutputData) => void;
 };
+
 export default function Editor({ setContent }: Props) {
   const ejInstance = useRef<EditorJS | null>(null);
+
   const initEditor = () => {
     const editor = new EditorJS({
       holder: "editorjs",
@@ -31,34 +32,64 @@ export default function Editor({ setContent }: Props) {
           class: Header as unknown as ToolConstructable,
           config: {
             placeholder: "Enter a header",
-            levels: [1, 2, 3, 4],
-            defaultLevel: 3,
+            levels: [1, 2, 3, 4, 5, 6],
+            defaultLevel: 1,
           },
         },
+      
+        image: ImageBlock,
         charts: ChartBLock,
         news: NewsBlock,
         Report: ReportBlock,
         finance: FinanceBlock,
         disclosure: DisclosureBlock,
-        paragraph: {
-          class: Paragraph,
-          config: {
-            preserveBlank: true,
-          },
-        },
       },
       autofocus: true,
     });
+
+    document.addEventListener('paste', handlePaste);
+
+    return () => {
+      document.removeEventListener('paste', handlePaste);
+      ejInstance?.current?.destroy();
+      ejInstance.current = null;
+    };
   };
+
+  const handlePaste = (event: ClipboardEvent) => {
+    event.preventDefault();
+    if (event.clipboardData) {
+      const items = event.clipboardData.items;
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].type.indexOf('image') !== -1) {
+          const file = items[i].getAsFile();
+          if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+              const url = e.target?.result as string;
+              insertImageBlock(url);
+            };
+            reader.readAsDataURL(file);
+          }
+        }
+      }
+    }
+  };
+
+  const insertImageBlock = (imageDataUrl: string) => {
+    if (ejInstance.current) {
+      ejInstance.current.blocks.insert('image', {
+          url: imageDataUrl
+      })
+    }
+  };
+
   useEffect(() => {
     if (ejInstance.current === null) {
       initEditor();
     }
-    return () => {
-      ejInstance?.current?.destroy();
-      ejInstance.current = null;
-    };
   }, []);
+
   return (
     <div
       id="editorjs"

--- a/frontend/src/routes/editor/component/blockTools/image/ImageBlock.tsx
+++ b/frontend/src/routes/editor/component/blockTools/image/ImageBlock.tsx
@@ -1,0 +1,57 @@
+import { API } from "@editorjs/editorjs/types/index";
+
+interface ReportBlockData {
+  data: ImageData;
+  api: API;
+}
+
+export interface ImageData {
+  url: string;
+}
+
+export class ImageBlock {
+  data: ImageData;
+  api: API;
+
+  constructor({ data, api }: ReportBlockData) {
+    this.data = data || null ;
+    this.api = api;
+  }
+
+  static get toolbox() {
+    return {
+      title: "이미지",
+      icon: "<svg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24'><path d='m19,0h-9c-2.757,0-5,2.243-5,5v1h-.5c-2.481,0-4.5,2.019-4.5,4.5v10c0,1.929,1.569,3.499,3.499,3.5h15.501c2.757,0,5-2.243,5-5V5c0-2.757-2.243-5-5-5ZM5,20.5c0,.827-.673,1.5-1.5,1.5s-1.5-.673-1.5-1.5v-10c0-1.378,1.122-2.5,2.5-2.5h.5v12.5Zm17-1.5c0,1.654-1.346,3-3,3H6.662c.216-.455.338-.963.338-1.5V5c0-1.654,1.346-3,3-3h9c1.654,0,3,1.346,3,3v14Zm-2-12c0,.552-.448,1-1,1h-3c-.552,0-1-.448-1-1s.448-1,1-1h3c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1Zm0,4c0,.552-.448,1-1,1h-9c-.552,0-1-.448-1-1s.448-1,1-1h9c.552,0,1,.448,1,1ZM9,7v-2c0-.552.448-1,1-1h2c.552,0,1,.448,1,1v2c0,.552-.448,1-1,1h-2c-.552,0-1-.448-1-1Z'/></svg>",
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  static get pasteConfig() {
+    return {
+      tags: ['img'],
+      patterns: {
+        image: '/https?:\\/\\/\\S+\\.(gif|jpe?g|tiff|png|webp|bmp)$/i',
+      },
+    };
+  }
+
+  render() {
+    const img = document.createElement('img');
+    img.src = this.data.url;
+    img.style.maxWidth = '100%';
+    img.style.textAlign = 'center'
+    this.data = { url: img.src };
+
+    return img;
+  }
+
+  save(blockContent: string) {
+    console.log(this.data)
+    return this.data;
+  }
+}
+
+export default ImageBlock;

--- a/frontend/src/routes/postDetail/component/ViewEditor.tsx
+++ b/frontend/src/routes/postDetail/component/ViewEditor.tsx
@@ -7,6 +7,7 @@ import { ChartBLock } from "../../editor/component/blockTools/chart/ChartBlock";
 import { ReportBlock } from "../../editor/component/blockTools/Report/ReportBlock";
 import { FinanceBlock } from "../../editor/component/blockTools/finance/FinanceBlock";
 import { DisclosureBlock } from "../../editor/component/blockTools/disclosure/DisclosureBlock";
+import { ImageBlock } from "../../editor/component/blockTools/image/ImageBlock";
 
 type props = {
   outPutData: OutputData;
@@ -25,6 +26,7 @@ export default function ViewEditor({ outPutData }: props) {
       },
       tools: {
         header: Header,
+        image: ImageBlock,
         news: NewsBlock,
         charts: ChartBLock,
         Report: ReportBlock,


### PR DESCRIPTION
### PR 타입
- [✅] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
seojeho->main

### 변경 사항
이미지를 그냥 복사하고 컨트롤 v하면 에디터에 작성하는 툴을 구현하였습니다.

### 테스트 결과

#에디터
![image](https://github.com/Typerproject/Frontend/assets/127959482/c303f50c-fe66-41e0-84df-ba008ec88c05)

#저장
![image](https://github.com/Typerproject/Frontend/assets/127959482/296bf906-fb85-4dfa-b4d5-d86988ca9756)
