### PR TITLE
포스트 삭제 기능

### DIFF
--- a/frontend/src/api/postDetailAPI.ts
+++ b/frontend/src/api/postDetailAPI.ts
@@ -56,7 +56,7 @@ export interface IPost {
   writer: IWriter;
   scrapingCount: number;
   isScrapped: boolean;
-  commnetCount: number;
+  commentCount: number;
 }
 
 // 메인 화면용 포스트 리스트를 담는 인터페이스
@@ -82,6 +82,11 @@ export default class postAPI extends BaseApi {
   async addPost(body: IPostBody) {
     const resp = await this.fetcher.post("/", body);
     return resp.data;
+  }
+
+  async deletePost(postId: string) {
+    const resp = await this.fetcher.delete(`/${postId}`);
+    return resp;
   }
 
   async scrapPost(postId: string) {

--- a/frontend/src/routes/postDetail/PostDetailPage.tsx
+++ b/frontend/src/routes/postDetail/PostDetailPage.tsx
@@ -25,6 +25,7 @@ export default function PostDetail() {
         .getPost(id)
         .then((res: IPostDetail) => {
           setPostDetail(res);
+          console.log(res);
           setIsWriter(userId === res.writer.writerId);
           setScrap(res.isScrapped);
           return res;
@@ -132,6 +133,7 @@ export default function PostDetail() {
           setScrap={setScrap}
           outputData={postDetail.content}
           scrapingCount={postDetail.scrapingCount}
+          writerId={postDetail.writer?.writerId}
         />
         {postDetail.writer && (
           <div

--- a/frontend/src/routes/postDetail/component/PostContent.tsx
+++ b/frontend/src/routes/postDetail/component/PostContent.tsx
@@ -2,11 +2,12 @@ import { IoBookmarkOutline, IoBookmark } from "react-icons/io5";
 import { useState, useEffect } from "react";
 import ViewEditor from "./ViewEditor";
 import postAPI, { IpostScrap } from "../../../api/postDetailAPI";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { OutputData } from "@editorjs/editorjs";
 import CommentList from "./CommentList";
 import { FaRegComment } from "react-icons/fa";
 import commentAPI from "../../../api/commentAPI";
+import { useAppSelector } from "../../../store";
 
 const service = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
@@ -15,6 +16,7 @@ type Props = {
   outputData: OutputData;
   setScrap: React.Dispatch<React.SetStateAction<boolean>>;
   scrapingCount: number;
+  writerId: string;
 };
 
 const commentService = new commentAPI(import.meta.env.VITE_BASE_URI);
@@ -29,10 +31,12 @@ export default function PostContent({
   setScrap,
   outputData,
   scrapingCount,
+  writerId,
 }: Props) {
   const [vaildComment, setValidComment] = useState<boolean>(false);
-
+  const currentUserId = useAppSelector((state) => state.user._id);
   const { id } = useParams<{ id: string }>() as { id: string };
+  const navigate = useNavigate();
 
   const [progress, setProgress] = useState<IprogressStyle>(
     {} as IprogressStyle
@@ -114,6 +118,22 @@ export default function PostContent({
     return () => window.removeEventListener("scroll", getElementPostion); // 클린업, 페이지를 나가면 이벤트 삭제
   }, []);
 
+  const clickDelete = async () => {
+    if (!confirm("정말 삭제하시겠습니까?")) {
+      return;
+    }
+
+    const resp = await service.deletePost(id);
+
+    if (resp.status !== 200) {
+      alert("게시글 삭제 실패");
+      return;
+    }
+
+    alert("삭제되었습니다.");
+    navigate(-1);
+  };
+
   return (
     <>
       <div
@@ -151,6 +171,14 @@ export default function PostContent({
           <div onClick={() => handleLike()} className="cursor-pointer">
             {scrap ? <IoBookmark size={20} /> : <IoBookmarkOutline size={20} />}
           </div>
+          {currentUserId === writerId && (
+            <div
+              className="text-red-400 hover:bg-gray-400 rounded"
+              onClick={clickDelete}
+            >
+              삭제
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main

### 변경 사항
이제 포스트를 삭제할 수 있습니다.
포스트 디테일 페이지에서 만약 해당 포스트의 작성자와 로그인중인 유저 (redux에 저장된 유저 ID) 가 동일하다면 삭제 버튼이 활성화 됩니다.

### 테스트 결과
![image](https://github.com/Typerproject/Frontend/assets/99272057/ffca4ebc-92ba-4b23-99c1-31fb115cb21d)
