### PR TITLE
✨ feat: 메인페이지 무한 스크롤, 슬라이더 반응형 높이 조절, 차트 input 모달 수정, 일부 페이지 css 수정

### DIFF
--- a/frontend/src/api/postDetailAPI.ts
+++ b/frontend/src/api/postDetailAPI.ts
@@ -56,7 +56,7 @@ export interface IPost {
   writer: IWriter;
   scrapingCount: number;
   isScrapped: boolean;
-  commnetCount: number;
+  commentCount: number;
 }
 
 // 메인 화면용 포스트 리스트를 담는 인터페이스

--- a/frontend/src/routes/editor/EditorPage.tsx
+++ b/frontend/src/routes/editor/EditorPage.tsx
@@ -63,7 +63,7 @@ export default function EditorPage() {
           >
             나가기
           </p>
-          <div className="flex items-center w-[10%] justify-between">
+          <div className="flex items-center gap-4">
             {isPublic ? (
               <IoMdUnlock
                 className="hover:opacity-80 cursor-pointer"

--- a/frontend/src/routes/editor/component/blockTools/chart/ChartBlock.tsx
+++ b/frontend/src/routes/editor/component/blockTools/chart/ChartBlock.tsx
@@ -187,6 +187,9 @@ const ChartModal = ({ setData, onExit }: ChartModalProps) => {
         e.preventDefault();
         if (selectedIndex !== -1) {
           handleSelect(filteredCodes[selectedIndex]);
+          setSelectedIndex(-1);
+          setFilteredCodes([]);
+          setShowDropdown(false);
         }
         break;
 
@@ -212,11 +215,19 @@ const ChartModal = ({ setData, onExit }: ChartModalProps) => {
     }
   };
 
-  // useEffect(() => {
-  //   if (dropdownRef.current) {
-  //     dropdownRef.current.focus();
-  //   }
-  // }, [showDropdown]);
+  useEffect(() => {
+    if (dropdownRef.current && selectedIndex !== -1) {
+      const selectedElement = dropdownRef.current.children[
+        selectedIndex
+      ] as HTMLElement;
+      if (selectedElement) {
+        selectedElement.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    }
+  }, [selectedIndex]);
 
   const handleCodeChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>

--- a/frontend/src/routes/main/MainPage.tsx
+++ b/frontend/src/routes/main/MainPage.tsx
@@ -84,32 +84,10 @@ const MyComponent = () => {
       // 현재 버튼이 클릭된 버튼과 같지 않을 때만 페이지 초기화
       setActiveButton(buttonName);
       setPage(1);
+      setPostList({ posts: [] });
       setIsLoading(true);
     }
   };
-
-  // useEffect(() => {
-  //   if (page === 1) {
-  //     // 첫 페이지 로드 시 초기화
-  //     setPostList({ posts: [] });
-  //   }
-
-  //   postService
-  //     .getPostListForMain(page, activeButton.toLowerCase())
-  //     .then((data) => {
-  //       console.log("메인 페이지 포스트 데이터 잘 가져와 지나??", data);
-  //       setPostList((prevPostList) => ({
-  //         ...prevPostList,
-  //         posts:
-  //           page === 1 ? data.posts : [...prevPostList.posts, ...data.posts],
-  //       }));
-
-  //       setIsLoading(false);
-  //     })
-  //     .catch((err) => {
-  //       console.error(err);
-  //     });
-  // }, [page, activeButton]);
 
   // 스크롤 맨 위로 올리는 함수
   const scrollToTop = () => {

--- a/frontend/src/routes/main/component/Post.tsx
+++ b/frontend/src/routes/main/component/Post.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from "react";
-import userAPI from "../../../api/userAPI";
+import { useState } from "react";
 import postAPI, { IPost } from "../../../api/postDetailAPI";
 import { FaRegComment, FaRegBookmark } from "react-icons/fa";
 import { FaBookmark } from "react-icons/fa6";
 import { useNavigate } from "react-router-dom";
 
-const useService = new userAPI(import.meta.env.VITE_BASE_URI);
 const postService = new postAPI(import.meta.env.VITE_SERVER_POST_API_URI);
 
 // 스크랩/코멘트 누르면 로그인 요청 알럿 + login 창 뜨도록?
@@ -72,7 +70,7 @@ export default function MainPost({ post }: MainPostProps) {
 
   return (
     <>
-      <div className="flex flex-row px-[1rem] py-[2rem] justify-between mb-4 hover:bg-gray-200 hover:rounded-lg">
+      <div className="flex flex-row px-[1rem] py-[2rem] justify-between mb-4 hover:bg-gray-200 hover:rounded-lg duration-200">
         <div className="flex-1 flex flex-col gap-[10px] justify-between">
           <div>
             <div className="flex cursor-pointer">
@@ -161,7 +159,6 @@ export default function MainPost({ post }: MainPostProps) {
               className="flex items-center gap-[0.5rem] cursor-pointer"
             >
               <FaRegComment size={16} />
-              {/* 코멘트 '개수'가 있다고 생각! */}
               <p>{post.commentCount}</p>
             </div>
           </div>

--- a/frontend/src/routes/main/component/Post.tsx
+++ b/frontend/src/routes/main/component/Post.tsx
@@ -64,10 +64,6 @@ export default function MainPost({ post }: MainPostProps) {
       });
   };
 
-  {
-    console.log("이름 왜 출력 안돼?: ", post.writer.nickname);
-  }
-
   return (
     <>
       <div className="flex flex-row px-[1rem] py-[2rem] justify-between mb-4 hover:bg-gray-200 hover:rounded-lg duration-200">

--- a/frontend/src/routes/main/component/SliderTest.tsx
+++ b/frontend/src/routes/main/component/SliderTest.tsx
@@ -19,6 +19,14 @@ const StyledSlider = styled(Slider)`
       font-size: 50px;
     }
   }
+
+  @media (max-width: 470px) {
+    .slick-track,
+    .slick-list {
+      height: 400px;
+    }
+    height: 400px;
+  }
 `;
 
 const SliderTest: React.FC = () => {
@@ -53,6 +61,29 @@ const SliderTest: React.FC = () => {
     autoplaySpeed: 2000,
     nextArrow: <NextArrow />,
     prevArrow: <PrevArrow />,
+    responsive: [
+      {
+        breakpoint: 1024,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1,
+        },
+      },
+      {
+        breakpoint: 768,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1,
+        },
+      },
+      {
+        breakpoint: 480,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1,
+        },
+      },
+    ],
   };
 
   function NextArrow(props: any) {
@@ -227,7 +258,7 @@ const SliderTest: React.FC = () => {
               <div className="flex flex-col items-center justify-center gap-12 h-full text-white text-center">
                 <p
                   style={{
-                    fontSize: "25px",
+                    fontSize: "21px",
                     color: "white",
                     wordBreak: "break-word",
                     width: "80%",
@@ -275,7 +306,7 @@ const SliderTest: React.FC = () => {
               <div className="flex flex-col items-center justify-center gap-12 h-full text-white text-center">
                 <p
                   style={{
-                    fontSize: "25px",
+                    fontSize: "21px",
                     color: "white",
                     wordBreak: "break-word",
                     width: "80%",


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
jaehyeon -> main

### 변경 사항
메인 페이지 - 슬라이드 반응형 높이 조정, 게시글 무한 스크롤을 따로 div 태그에 가두지 않고 밖으로 꺼냄
차트블럭 유저 input 모달 - 종목 코드에서 종목 이름으로, 드롭다운 기능 추가

### 테스트 결과

### 메인페이지 슬라이더 이전엔 높이가 길어서 보기 좋지 않았음
![메인페이지반응형및이슈확인](https://github.com/Typerproject/Frontend/assets/81346079/17c6f8a5-35b1-44df-8b28-e4ad2bcd80fd)

### 무한 스크롤 수정
![무한스크롤](https://github.com/Typerproject/Frontend/assets/81346079/c2484744-9cf8-4d16-898b-19c123c1e336)

### 차트 드롭다운
![차트검색드롭다운](https://github.com/Typerproject/Frontend/assets/81346079/7405c740-7db0-4212-a4b6-28aba03fa526)
