### PR TITLE
feat: 댓글 삭제 기능 추가

### DIFF
--- a/frontend/src/routes/postDetail/component/Comment.tsx
+++ b/frontend/src/routes/postDetail/component/Comment.tsx
@@ -1,11 +1,13 @@
 // import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import Reply from "./Reply";
+import { useAppSelector } from "../../../store";
 import { useState } from "react";
 
 export default function Comment({ comment, service }) {
   const [text, setText] = useState<string>("");
   const { id } = useParams<{ id: string }>() as { id: string };
+  const currentUserId = useAppSelector((state) => state.user._id);
 
   const parsingDate = (): string => {
     const date = new Date(comment.createdAt);
@@ -45,29 +47,57 @@ export default function Comment({ comment, service }) {
 
   const [validInput, setValidInput] = useState<boolean>(false);
 
+  const deleteComment = async () => {
+    if (!confirm("정말 삭제하시겠습니까?")) {
+      return;
+    }
+    console.log(comment._id);
+
+    const res = await service.deleteComment(comment._id);
+
+    console.log(res);
+    if (res.status === 200) {
+      history.scrollRestoration = "auto";
+      location.reload();
+      alert("삭제되었습니다.");
+      return;
+    }
+    alert("삭제 실패");
+  };
+
   return (
     <>
-      <div className="flex gap-[1rem] my-[36px] w-full">
-        <div
-          style={{
-            backgroundImage: `url(${comment.writerId.profile})`,
-          }}
-          className="w-[32px] h-[32px] rounded-full bg-cover bg-center cursor-pointer"
-        ></div>
-        <div style={{ width: "calc(100% - 32px)" }}>
-          <div className="mb-[1rem]">
-            <p className="text-sm">{comment.writerId.nickname}</p>
-            <p className="text-xs text-gray-500">{parsingDate()}</p>
-          </div>
+      <div className="flex gap-[1rem] my-[36px] w-full justify-between items-center">
+        <div className="flex gap-[1rem] my-[36px] w-full">
+          <div
+            style={{
+              backgroundImage: `url(${comment.writerId.profile})`,
+            }}
+            className="w-[32px] h-[32px] rounded-full bg-cover bg-center cursor-pointer"
+          ></div>
+          <div style={{ width: "calc(100% - 32px)" }}>
+            <div className="mb-[1rem]">
+              <p className="text-sm">{comment.writerId.nickname}</p>
+              <p className="text-xs text-gray-500">{parsingDate()}</p>
+            </div>
 
-          <p className="mb-[1rem]">{comment.text}</p>
-          <button
-            onClick={() => setValidInput((prev) => !prev)}
-            className="text-xs text-gray-500"
-          >
-            답글 달기
-          </button>
+            <p className="mb-[1rem]">{comment.text}</p>
+            <button
+              onClick={() => setValidInput((prev) => !prev)}
+              className="text-xs text-gray-500"
+            >
+              답글 달기
+            </button>
+          </div>
         </div>
+        {currentUserId === comment.writerId.id && (
+          <div
+            className="flex w-[5%] h-fit justify-center hover:bg-red-200 rounded"
+            onClick={deleteComment}
+          >
+            삭제
+          </div>
+        )}
       </div>
       {validInput && (
         <div className="pl-[32px] w-full flex flex-col gap-[1rem] items-end	">
@@ -81,13 +111,13 @@ export default function Comment({ comment, service }) {
             onClick={submitComment}
             className="m-0 text-xs border-[1px] bg-gray-900 text-gray-50 rounded-full border-black text-sm px-[0.7rem] pt-[0.5rem] pb-[0.3rem] hover:bg-white hover:text-black duration-300"
           >
-            전송
+            답글 달기
           </button>
         </div>
       )}
 
       {comment.replies.map((ele, idx) => {
-        return <Reply key={idx} reply={ele} />;
+        return <Reply key={idx} reply={ele} service={service} />;
       })}
     </>
   );

--- a/frontend/src/routes/postDetail/component/CommentList.tsx
+++ b/frontend/src/routes/postDetail/component/CommentList.tsx
@@ -31,7 +31,12 @@ export default function CommentList({ comments }) {
 
   return (
     <div className="mb-[5rem]">
-      <p>댓글 {comments.length}</p>
+      <p>
+        댓글{" "}
+        {comments.reduce((acc, cur) => {
+          return acc + 1 + cur.replies.length;
+        }, 0)}
+      </p>
       <hr className="my-[2rem]" />
 
       {comments.map((ele, idx) => {

--- a/frontend/src/routes/postDetail/component/Reply.tsx
+++ b/frontend/src/routes/postDetail/component/Reply.tsx
@@ -1,6 +1,10 @@
 // type Props = {};
 
-export default function Reply({ reply }) {
+import { useAppSelector } from "../../../store";
+
+export default function Reply({ reply, service }) {
+  const currentUserId = useAppSelector((state) => state.user._id);
+
   const parsingDate = (): string => {
     const date = new Date(reply.createdAt);
 
@@ -13,6 +17,23 @@ export default function Reply({ reply }) {
       second: "2-digit",
     });
     return formattedTime;
+  };
+
+  const deleteComment = async () => {
+    if (!confirm("정말 삭제하시겠습니까?")) {
+      return;
+    }
+
+    const res = await service.deleteComment(reply._id);
+
+    console.log(res);
+    if (res.status === 200) {
+      history.scrollRestoration = "auto";
+      location.reload();
+      alert("삭제되었습니다.");
+      return;
+    }
+    alert("삭제 실패");
   };
 
   return (
@@ -28,9 +49,16 @@ export default function Reply({ reply }) {
           <p className="text-sm">{reply.writerId.nickname}</p>
           <p className="text-xs text-gray-500">{parsingDate()}</p>
         </div>
-
         <p className="mb-[1rem]">{reply.text}</p>
       </div>
+      {currentUserId === reply.writerId.id && (
+        <div
+          className="flex w-[5%] h-fit justify-center hover:bg-red-200 rounded"
+          onClick={deleteComment}
+        >
+          삭제
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) yapyap -> main

### 변경 사항
댓글 삭제 기능이 추가되었습니다.
로그인한 본인의 댓글 옆에 삭제 버튼이 활성화 됩니다. 댓글 수가 잘못 표시되던 버그도 수정했습니다.

### 테스트 결과
![image](https://github.com/Typerproject/Frontend/assets/99272057/487fc668-5342-41cc-908e-27cc136b39a0)

