### PR TITLE
feat: 에디터 페이지 width 768 이하 인 경우 접근 제한

### DIFF
--- a/frontend/src/routes/editor/component/Editor.tsx
+++ b/frontend/src/routes/editor/component/Editor.tsx
@@ -8,6 +8,7 @@ import { ReportBlock } from "./blockTools/Report/ReportBlock";
 import { type ToolConstructable, OutputData } from "@editorjs/editorjs";
 import { DisclosureBlock } from "./blockTools/disclosure/DisclosureBlock";
 import { ImageBlock } from "./blockTools/image/ImageBlock";
+import { useNavigate } from "react-router-dom";
 
 type Props = {
   setContent: (value: OutputData) => void;
@@ -15,6 +16,7 @@ type Props = {
 
 export default function Editor({ setContent }: Props) {
   const ejInstance = useRef<EditorJS | null>(null);
+  const navigate = new useNavigate();
 
   const initEditor = () => {
     const editor = new EditorJS({
@@ -36,7 +38,6 @@ export default function Editor({ setContent }: Props) {
             defaultLevel: 1,
           },
         },
-
 
         image: ImageBlock,
         charts: ChartBLock,
@@ -95,6 +96,12 @@ export default function Editor({ setContent }: Props) {
 
   useEffect(() => {
     if (ejInstance.current === null) {
+      if (window.innerWidth <= 768) {
+        alert("에디터는 모바일에서 사용할 수 없습니다. PC를 사용해주세요");
+        navigate(-1);
+        return;
+      }
+
       initEditor();
     }
   }, []);


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main 


### 변경 사항
에디터 페이지는 모바일에서 사용하기에는 어려움이 있어 width가 768 이하인 디바이스는 접근할 수 없도록 수정했습니다.